### PR TITLE
Add fileSize field to API response

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,8 @@ import uuidV4 from 'uuid/v4'
 import exphbs from 'express-handlebars'
 import {List} from 'immutable'
 import {checkHash} from './hash-util'
-import {dogFolderName, getDoggoCount, getGoodDogs, getNewDogs, rejectDog, adoptDog} from './fs-layer'
+import {dogFolderName, getDoggoCount, getGoodDogs, getNewDogs, getDogFileSize, rejectDog, adoptDog} from './fs-layer'
+
 import {DogError} from './dog-error'
 import {DogCache} from './DogCache'
 
@@ -91,11 +92,14 @@ export const createApp = async (host) => {
         res.status(200).send(getDogsMaybeWithFilter(req).random())
     })
 
-    app.get('/woof.json', (req, res) => {
+    app.get('/woof.json', async (req, res) => {
         req.visitor.event('woof.json', 'GET', 'api').send()
         setCORSHeaders(res)
+        const dogName = getDogsMaybeWithFilter(req).random()
+        const fileSize = await getDogFileSize(dogName)
         res.status(200).json({
-            url: `${host}/${getDogsMaybeWithFilter(req).random()}`
+            fileSize,
+            url: `${host}/${dogName}`
         })
     })
 

--- a/src/fs-layer.js
+++ b/src/fs-layer.js
@@ -35,3 +35,8 @@ export async function adoptDog(dogName) {
 
     await fs.move(rejectDogPath, `./${dogFolderName.approved}/${dogName}`, {overwrite: true})
 }
+
+export async function getDogFileSize(dogName) {
+    const stat = await fs.stat(`./${dogFolderName.approved}/${dogName}`)
+    return stat.size
+}

--- a/test/randomdog-tests.js
+++ b/test/randomdog-tests.js
@@ -12,6 +12,7 @@ describe('randomdog', () => {
         sandbox = sinon.sandbox.create()
         sandbox.stub(fsLayer, 'getGoodDogs').resolves(['testDog.jpg'])
         sandbox.stub(fsLayer, 'adoptDog')
+        sandbox.stub(fsLayer, 'getDogFileSize')
         sandbox.stub(hashUtil, 'checkHash').callsFake(key => key === 'goodKey')
     })
     afterEach(() => {
@@ -56,12 +57,14 @@ describe('randomdog', () => {
         it('should go woof', async () => {
             // @ts-ignore
             fsLayer.getGoodDogs.resolves(['testDog.jpg'])
+            fsLayer.getDogFileSize.resolves(67107)
             return request(await createApp('test_host'))
                 .get('/woof.json')
                 .expect('Content-Type', /json/)
                 .expect(200)
                 .then(response => {
                     expect(response.body.url).to.equal('test_host/testDog.jpg')
+                    expect(response.body.fileSize).to.equal(67107)
                 })
         })
         it('should not return jpeg dogs when filter is jpg', async () => {


### PR DESCRIPTION
This PR adds the file size of a doggo to the API. I opted for `fileSize` as opposed to `size`, since it might be confused with the width/height of the resource.

**Why is this needed?**
Some users of the API might be interested in the file size before using it, and fetching another doggo if the size is too big.

For example, GitHub uses [Camo](https://github.com/atmos/camo) with a max content-length restriction, and you'll end up with broken images if they exceed this limit.